### PR TITLE
Delete ep_disableChat plugin and upgrade docker to use etherpad version 1.8.3 [IST-34]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Inspired by https://github.com/ether/etherpad-lite/blob/develop/Dockerfile
 FROM node:alpine3.11
-LABEL version="1.8.0"
+LABEL version="1.8.3"
 LABEL maintainer="IST Schoolbox <ist@schoolbox.com.au>"
 
-ARG ETHERPAD_VERSION=1.8.0
+ARG ETHERPAD_VERSION=1.8.3
 ARG ETHERPAD_PLUGINS="redis ep_disable_change_author_name ep_headings"
 ARG PKGS_TO_DEL="make gcc g++ linux-headers openssl" 
 ARG DIRS_TO_DEL="/var/cache/apk/*" 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL version="1.8.0"
 LABEL maintainer="IST Schoolbox <ist@schoolbox.com.au>"
 
 ARG ETHERPAD_VERSION=1.8.0
-ARG ETHERPAD_PLUGINS="redis ep_disableChat ep_disable_change_author_name ep_headings"
+ARG ETHERPAD_PLUGINS="redis ep_disable_change_author_name ep_headings"
 ARG PKGS_TO_DEL="make gcc g++ linux-headers openssl" 
 ARG DIRS_TO_DEL="/var/cache/apk/*" 
 ARG PAD_BUILD_DEPENDENCY="openssl openssl-dev pcre pcre-dev zlib zlib-dev"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Once successful, you should be able to access http://localhost:9001
 ## Installed plugins
 
 - redis
-- ep_disableChat
 - ep_disable_change_author_name
 - ep_headings
 


### PR DESCRIPTION
If we don't want to upgrade for now, kindly review/merge the [PR](https://github.com/alaress/schoolbox-epl/pull/4) that will just remove **ep_disableChat** plugin first. Thank you.